### PR TITLE
Android compatibility

### DIFF
--- a/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
+++ b/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -348,7 +347,7 @@ public class ClassIndex {
 			return null;
 		}
 		try {
-			try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), "UTF-8"))) {
 				StringBuilder builder = new StringBuilder();
 				String line = reader.readLine();
 				while (line != null) {
@@ -379,7 +378,7 @@ public class ClassIndex {
 
 			while (resources.hasMoreElements()) {
 				URL resource = resources.nextElement();
-				try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+				try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), "UTF-8"))) {
 
 					String line = reader.readLine();
 					while (line != null) {


### PR DESCRIPTION
We are using this library to build the Android version of the BUX App (http://getbux.com/).

As java.nio.charset.StandardCharsets is only available on Android since API level 19 (KitKat) and it is not yet widely adopted among Android users (https://developer.android.com/about/dashboards/index.html), a solution as simple as using the "UTF-8" String instead of the StandardCharsets was needed.

It is important to notice that another step is needed for Android compatibility: since the files ClassIndex generates are not automatically embedded into the APK build files, one small change is needed on the App developer side, since it touches the App packaging. If the author would be interested, I could add the gradle snippet we use for fixing this.
