### PR TITLE
Fix naming error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ There are two steps necessary:
 1.	First create a custom processor
 
 	```java
-	public class CustomProcessor extends ClassIndexProcessor {
-		public ImportantClassIndexProcessor() {
+	public class MyImportantClassIndexProcessor extends ClassIndexProcessor {
+		public MyImportantClassIndexProcessor() {
 			indexAnnotations(Entity.class);
 		}
 	}


### PR DESCRIPTION
The contructor name did not match the class name in the custom processor example.