### PR TITLE
Added support for repeated annotations in java 8

### DIFF
--- a/classindex/pom.xml
+++ b/classindex/pom.xml
@@ -117,6 +117,16 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+					<testSource>8</testSource>
+					<testTarget>8</testTarget>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/classindex/src/main/java/org/atteo/classindex/processor/ClassIndexProcessor.java
+++ b/classindex/src/main/java/org/atteo/classindex/processor/ClassIndexProcessor.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Inherited;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -36,6 +37,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -151,6 +153,7 @@ public class ClassIndexProcessor extends AbstractProcessor {
 					public Void visitType(TypeElement typeElement, Void o) {
 						try {
 							for (AnnotationMirror mirror : typeElement.getAnnotationMirrors()) {
+								storeRepeatableAnnotation(mirror, typeElement);
 								final TypeElement annotationElement = (TypeElement) mirror.getAnnotationType().asElement();
 								storeAnnotation(annotationElement, typeElement);
 							}
@@ -186,6 +189,20 @@ public class ClassIndexProcessor extends AbstractProcessor {
 		}
 
 		return false;
+	}
+
+	private void storeRepeatableAnnotation(final AnnotationMirror annotation, final TypeElement typeElement) throws IOException {
+		for (final AnnotationValue annotationField : annotation.getElementValues().values()) {
+			if (annotationField.getValue() instanceof List) {
+				for (final Object annotationFieldValue : (List)annotationField.getValue()) {
+					if (annotationFieldValue instanceof AnnotationMirror) {
+						final AnnotationMirror mirror = (AnnotationMirror) annotationFieldValue;
+						final TypeElement annotationElement = (TypeElement) mirror.getAnnotationType().asElement();
+						storeAnnotation(annotationElement, typeElement);
+					}
+				}
+			}
+		}
 	}
 
 	private void writeIndexFiles(String prefix, Map<String, Set<String>> indexMap) throws IOException {

--- a/classindex/src/test/java/org/atteo/classindex/ClassIndexTest.java
+++ b/classindex/src/test/java/org/atteo/classindex/ClassIndexTest.java
@@ -186,4 +186,10 @@ public class ClassIndexTest {
 	public void shouldStoreSummaryForSubclasses() {
 		assertEquals("First module", ClassIndex.getClassSummary(FirstModule.class));
 	}
+
+	@Test
+	public void shouldIndexClassesWithRepeatedAnnotations() {
+		Iterable<Class<?>> annotated = ClassIndex.getAnnotated(RepeatableAnnotation.class);
+		assertThat(annotated).contains(StandardRepeated.class, Java8Repeated.class);
+	}
 }

--- a/classindex/src/test/java/org/atteo/classindex/Java8Repeated.java
+++ b/classindex/src/test/java/org/atteo/classindex/Java8Repeated.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+@RepeatableAnnotation("Annotation1")
+@RepeatableAnnotation("Annotation2")
+public class Java8Repeated {
+}

--- a/classindex/src/test/java/org/atteo/classindex/MergingAnnotation.java
+++ b/classindex/src/test/java/org/atteo/classindex/MergingAnnotation.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MergingAnnotation {
+    RepeatableAnnotation[] value();
+}

--- a/classindex/src/test/java/org/atteo/classindex/RepeatableAnnotation.java
+++ b/classindex/src/test/java/org/atteo/classindex/RepeatableAnnotation.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IndexAnnotated(storeJavadoc = true)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(MergingAnnotation.class)
+public @interface RepeatableAnnotation {
+    String value();
+}

--- a/classindex/src/test/java/org/atteo/classindex/StandardRepeated.java
+++ b/classindex/src/test/java/org/atteo/classindex/StandardRepeated.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+import java.lang.annotation.Repeatable;
+
+@MergingAnnotation({@RepeatableAnnotation("Annotation1"),@RepeatableAnnotation("Annotation2")})
+public class StandardRepeated {
+}


### PR DESCRIPTION
If you want to annotate class few times with the same annotation you could do it this way:

1. Java 6 and 7
```
@ExampleAnnotations(@ExampleAnnotation("Example1"), @ExampleAnnotation("Example2"))
public class SomeClass {//...
```

2. Java 8 and above
```
@ExampleAnnotation("Example1")
@ExampleAnnotation("Example2")
public class SomeClass {//...
```

In first case before my modification you have to mark `@ExampleAnnotations` with `@IndexAnnotated`, and search for classes annotated with `@ExampleAnnotations` instead of `@ExampleAnnotation` after fix everything work as it should without any additional code.

In second case `@ExampleAnnotation` had to have `@Repeatable` annotation with value set as ExampleAnnotations.class.
`@Repeatable` annotation is compiled by another Annotation Processor which creates on-the-fly synthesized `@ExampleAnnotations(@ExampleAnnotation("Example1"), @ExampleAnnotation("Example2"))` with missing metadata so it did not work.
After my fix everything works fine.

I've done it by adding new function in ClassIndexProcessor which checks every field in found annotation does it return list of another indexed annotations.

In pom.xml I've added testSource and testTarget to 8 and leave source and target as 1.7 because I don't know if you want to upgrade whole project to java 8. It makes little problem in IntelliJ because it doesn't support different java versions in one module but maven build work as it should.