### PR TITLE
Fix packaging type in order to correctly provide OSGi bundle

### DIFF
--- a/classindex/pom.xml
+++ b/classindex/pom.xml
@@ -8,6 +8,7 @@
 	</parent>
 	<artifactId>classindex</artifactId>
 	<name>Atteo Class Index</name>
+	<packaging>bundle</packaging>
 	<dependencies>
 		<dependency>
 			<groupId>com.google.guava</groupId>


### PR DESCRIPTION
In PR #50 the maven-bundle plugin was added correctly, but somehow the `<packaging>bundle</packaging>` was either lost during the merge or forgotten in the first place.
Without that special packaging (which is compatible to `jar` being the default when omitted), no OSGi manifest is generated.

Classindex 3.7 unfortunately is not usable in OSGi environments therefore.