### PR TITLE
Catch NoClassDefFoundError too

### DIFF
--- a/classindex-transformer/src/it/simple/compiletimemodule/pom.xml
+++ b/classindex-transformer/src/it/simple/compiletimemodule/pom.xml
@@ -6,9 +6,9 @@
 		<artifactId>classindex-transformer-test</artifactId>
 		<version>@project.version@</version>
 	</parent>
-	<artifactId>classindex-transformer-test-first</artifactId>
+	<artifactId>classindex-transformer-test-compiletimemodule</artifactId>
 	<version>@project.version@</version>
-	<name>ClassIndex Transformer Test First</name>
+	<name>ClassIndex Transformer Test CompileTime Module(This Module is used by the first module at compile time but not at runtime)</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.atteo.classindex</groupId>
@@ -17,9 +17,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.atteo.classindex</groupId>
-			<artifactId>classindex-transformer-test-compiletimemodule</artifactId>
+			<artifactId>classindex-transformer-test-parentmodule</artifactId>
 			<version>${project.version}</version>
-			<optional>true</optional>
 		</dependency>
 	</dependencies>
 </project>

--- a/classindex-transformer/src/it/simple/compiletimemodule/src/main/java/org/atteo/classindex/CompileTimeService.java
+++ b/classindex-transformer/src/it/simple/compiletimemodule/src/main/java/org/atteo/classindex/CompileTimeService.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+public interface CompileTimeService extends ParentService {
+}

--- a/classindex-transformer/src/it/simple/compiletimemodule/src/main/java/org/atteo/classindex/CompileTimeServiceImpl.java
+++ b/classindex-transformer/src/it/simple/compiletimemodule/src/main/java/org/atteo/classindex/CompileTimeServiceImpl.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+public class CompileTimeServiceImpl implements CompileTimeService {
+
+}

--- a/classindex-transformer/src/it/simple/first/src/main/java/org/atteo/classindex/FirstCompileTimeServiceImpl.java
+++ b/classindex-transformer/src/it/simple/first/src/main/java/org/atteo/classindex/FirstCompileTimeServiceImpl.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+public class FirstCompileTimeServiceImpl implements ParentService, CompileTimeService {
+
+}

--- a/classindex-transformer/src/it/simple/first/src/main/java/org/atteo/classindex/FirstParentService.java
+++ b/classindex-transformer/src/it/simple/first/src/main/java/org/atteo/classindex/FirstParentService.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+public class FirstParentService implements ParentService {
+
+}

--- a/classindex-transformer/src/it/simple/parentmodule/pom.xml
+++ b/classindex-transformer/src/it/simple/parentmodule/pom.xml
@@ -6,20 +6,14 @@
 		<artifactId>classindex-transformer-test</artifactId>
 		<version>@project.version@</version>
 	</parent>
-	<artifactId>classindex-transformer-test-first</artifactId>
+	<artifactId>classindex-transformer-test-parentmodule</artifactId>
 	<version>@project.version@</version>
-	<name>ClassIndex Transformer Test First</name>
+	<name>ClassIndex Transformer Test Parent Module</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.atteo.classindex</groupId>
 			<artifactId>classindex</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.atteo.classindex</groupId>
-			<artifactId>classindex-transformer-test-compiletimemodule</artifactId>
-			<version>${project.version}</version>
-			<optional>true</optional>
 		</dependency>
 	</dependencies>
 </project>

--- a/classindex-transformer/src/it/simple/parentmodule/src/main/java/org/atteo/classindex/CustomAnnotation.java
+++ b/classindex-transformer/src/it/simple/parentmodule/src/main/java/org/atteo/classindex/CustomAnnotation.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+@IndexAnnotated
+public @interface CustomAnnotation {
+
+}

--- a/classindex-transformer/src/it/simple/parentmodule/src/main/java/org/atteo/classindex/ParentService.java
+++ b/classindex-transformer/src/it/simple/parentmodule/src/main/java/org/atteo/classindex/ParentService.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+@CustomAnnotation
+@IndexSubclasses
+public interface ParentService {
+}

--- a/classindex-transformer/src/it/simple/pom.xml
+++ b/classindex-transformer/src/it/simple/pom.xml
@@ -7,6 +7,8 @@
 	<packaging>pom</packaging>
 	<name>ClassIndex Transformer Test</name>
 	<modules>
+		<module>parentmodule</module>
+		<module>compiletimemodule</module>
 		<module>first</module>
 		<module>second</module>
 	</modules>

--- a/classindex-transformer/src/it/simple/second/pom.xml
+++ b/classindex-transformer/src/it/simple/second/pom.xml
@@ -13,6 +13,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.atteo.classindex</groupId>
+			<artifactId>classindex-transformer-test-parentmodule</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.atteo.classindex</groupId>
 			<artifactId>classindex-transformer-test-first</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/classindex-transformer/src/it/simple/second/src/main/java/org/atteo/classindex/ClassIndexTest.java
+++ b/classindex-transformer/src/it/simple/second/src/main/java/org/atteo/classindex/ClassIndexTest.java
@@ -24,9 +24,15 @@ public class ClassIndexTest {
 		assertEquals(2, size(annotated));
 		Iterable<Class<?>> packageSubclasses = ClassIndex.getPackageClasses(
 				ClassIndexTest.class.getPackage().getName());
-		assertEquals(7, size(packageSubclasses));
+		assertEquals(9, size(packageSubclasses));
 		ServiceLoader<Service> loader = ServiceLoader.load(Service.class);
 		assertEquals(2, size(loader));
+
+		Iterable<Class<? extends ParentService>> parentServices = ClassIndex.getSubclasses(ParentService.class);
+		assertEquals(2, size(parentServices));
+
+		Iterable<Class<?>> customAnnotationClasses = ClassIndex.getAnnotated(CustomAnnotation.class);
+		assertEquals(2, size(parentServices));
 	}
 
 	private static void assertEquals(int expected, int actual) {

--- a/classindex-transformer/src/it/simple/second/src/main/java/org/atteo/classindex/SecondParentService.java
+++ b/classindex-transformer/src/it/simple/second/src/main/java/org/atteo/classindex/SecondParentService.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.atteo.classindex;
+
+public class SecondParentService implements ParentService {
+}

--- a/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
+++ b/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
@@ -417,7 +417,7 @@ public class ClassIndex {
 			Class<?> klass;
 			try {
 				klass = classLoader.loadClass(packageName + "." + entry);
-			} catch (ClassNotFoundException e) {
+			} catch (ClassNotFoundException | NoClassDefFoundError e) {
 				continue;
 			}
 			classes.add(klass);

--- a/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
+++ b/classindex/src/main/java/org/atteo/classindex/ClassIndex.java
@@ -401,7 +401,7 @@ public class ClassIndex {
 			Class<?> klass;
 			try {
 				klass = classLoader.loadClass(entry);
-			} catch (ClassNotFoundException e) {
+			} catch (ClassNotFoundException | NoClassDefFoundError e) {
 				continue;
 			}
 			classes.add(klass);


### PR DESCRIPTION
Related to #56 we need to catch also NoClassDefFoundError too for when classes were present at compile time but missing at runtime.